### PR TITLE
use typename instead of name

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -17,13 +17,25 @@
         "scope": "jesus-film.ark",
         "version": "0.0.1",
         "mainFile": "index.ts",
-        "rootDir": "src/elements/block"
+        "rootDir": "src/elements/block",
+        "nextVersion": {
+            "version": "patch",
+            "message": "use __typename",
+            "username": "Tataihono Nikora",
+            "email": "tataihono.nikora@gmail.com"
+        }
     },
     "elements/core": {
         "scope": "jesus-film.ark",
         "version": "0.0.3",
         "mainFile": "index.ts",
-        "rootDir": "src/elements/core"
+        "rootDir": "src/elements/core",
+        "nextVersion": {
+            "version": "patch",
+            "message": " (bump dependencies versions)",
+            "username": "Tataihono Nikora",
+            "email": "tataihono.nikora@gmail.com"
+        }
     },
     "elements/donate": {
         "scope": "jesus-film.ark",
@@ -77,7 +89,13 @@
         "scope": "jesus-film.ark",
         "version": "0.0.1",
         "mainFile": "index.ts",
-        "rootDir": "src/elements/post"
+        "rootDir": "src/elements/post",
+        "nextVersion": {
+            "version": "patch",
+            "message": " (bump dependencies versions)",
+            "username": "Tataihono Nikora",
+            "email": "tataihono.nikora@gmail.com"
+        }
     },
     "elements/post-card": {
         "scope": "jesus-film.ark",

--- a/src/elements/block/block.spec.tsx
+++ b/src/elements/block/block.spec.tsx
@@ -7,33 +7,47 @@ describe('block', () => {
   it('should render paragraph', () => {
     const { getByTestId } = render(
       <Block
-        {...blocks.filter((block) => block.name === 'core/paragraph')[0]}
+        {...blocks.filter(
+          (block) => block.__typename === 'CoreParagraphBlock'
+        )[0]}
       />
     )
-    expect(getByTestId('core/paragraph')).toBeInTheDocument()
+    expect(getByTestId('CoreParagraphBlock')).toBeInTheDocument()
   })
   it('should render image', () => {
     const { getByTestId } = render(
-      <Block {...blocks.filter((block) => block.name === 'core/image')[0]} />
+      <Block
+        {...blocks.filter((block) => block.__typename === 'CoreImageBlock')[0]}
+      />
     )
-    expect(getByTestId('core/image')).toBeInTheDocument()
+    expect(getByTestId('CoreImageBlock')).toBeInTheDocument()
   })
   it('should render heading', () => {
     const { getByTestId } = render(
-      <Block {...blocks.filter((block) => block.name === 'core/heading')[0]} />
+      <Block
+        {...blocks.filter(
+          (block) => block.__typename === 'CoreHeadingBlock'
+        )[0]}
+      />
     )
-    expect(getByTestId('core/heading')).toBeInTheDocument()
+    expect(getByTestId('CoreHeadingBlock')).toBeInTheDocument()
   })
   it('should render list', () => {
     const { getByTestId } = render(
-      <Block {...blocks.filter((block) => block.name === 'core/list')[0]} />
+      <Block
+        {...blocks.filter((block) => block.__typename === 'CoreListBlock')[0]}
+      />
     )
-    expect(getByTestId('core/list')).toBeInTheDocument()
+    expect(getByTestId('CoreListBlock')).toBeInTheDocument()
   })
   it('should render gallery', () => {
     const { getByTestId } = render(
-      <Block {...blocks.filter((block) => block.name === 'core/gallery')[0]} />
+      <Block
+        {...blocks.filter(
+          (block) => block.__typename === 'CoreGalleryBlock'
+        )[0]}
+      />
     )
-    expect(getByTestId('core/gallery')).toBeInTheDocument()
+    expect(getByTestId('CoreGalleryBlock')).toBeInTheDocument()
   })
 })

--- a/src/elements/block/block.tsx
+++ b/src/elements/block/block.tsx
@@ -13,16 +13,16 @@ export type BlockProps =
   | CoreGalleryProps
 
 export function Block(BlockProps: BlockProps) {
-  switch (BlockProps.name) {
-    case 'core/image':
+  switch (BlockProps.__typename) {
+    case 'CoreImageBlock':
       return <CoreImage {...BlockProps} />
-    case 'core/paragraph':
+    case 'CoreParagraphBlock':
       return <CoreParagraph {...BlockProps} />
-    case 'core/heading':
+    case 'CoreHeadingBlock':
       return <CoreHeading {...BlockProps} />
-    case 'core/list':
+    case 'CoreListBlock':
       return <CoreList {...BlockProps} />
-    case 'core/gallery':
+    case 'CoreGalleryBlock':
       return <CoreGallery {...BlockProps} />
   }
 }

--- a/src/elements/block/blockData.ts
+++ b/src/elements/block/blockData.ts
@@ -6,10 +6,10 @@ export const blocks = [
       content:
         "When people talk about the ministry of Jesus, it's easy to focus on his miracles. Jesus performed some amazing feats that the world had never seen (and hasn’t seen since). But one of the most exciting things about His ministry was His teaching style."
     },
-    name: 'core/paragraph'
+    __typename: 'CoreParagraphBlock'
   },
   {
-    name: 'core/list',
+    __typename: 'CoreListBlock',
     attributes: {
       ordered: false,
       values:
@@ -17,7 +17,7 @@ export const blocks = [
     }
   },
   {
-    name: 'core/heading',
+    __typename: 'CoreHeadingBlock',
     attributes: {
       align: '',
       textAlign: '',
@@ -26,7 +26,7 @@ export const blocks = [
     }
   },
   {
-    name: 'core/image',
+    __typename: 'CoreImageBlock',
     attributes: {
       id: 23,
       href: '',
@@ -38,7 +38,7 @@ export const blocks = [
     }
   },
   {
-    name: 'core/gallery',
+    __typename: 'CoreGalleryBlock',
     attributes: {
       images: [
         {

--- a/src/elements/block/core-gallery/core-gallery.composition.tsx
+++ b/src/elements/block/core-gallery/core-gallery.composition.tsx
@@ -3,5 +3,7 @@ import { Block } from '..'
 import { blocks } from '../blockData'
 
 export const GalleryBlock = () => (
-  <Block {...blocks.filter((block) => block.name === 'core/gallery')[0]} />
+  <Block
+    {...blocks.filter((block) => block.__typename === 'CoreGalleryBlock')[0]}
+  />
 )

--- a/src/elements/block/core-gallery/core-gallery.spec.tsx
+++ b/src/elements/block/core-gallery/core-gallery.spec.tsx
@@ -5,7 +5,7 @@ import { CoreGallery } from '.'
 it('should render with the correct text', () => {
   const { getByAltText } = render(
     <CoreGallery
-      name="core/gallery"
+      __typename="CoreGalleryBlock"
       attributes={{
         images: [
           {

--- a/src/elements/block/core-gallery/core-gallery.tsx
+++ b/src/elements/block/core-gallery/core-gallery.tsx
@@ -18,17 +18,13 @@ export type CoreGalleryProps = {
    * container for image attributes
    */
   attributes: Attributes
-  /** Variant style */
-  name: 'core/gallery'
+  __typename: 'CoreGalleryBlock'
 }
 
-export function CoreGallery({
-  name,
-  attributes: { images }
-}: CoreGalleryProps) {
+export function CoreGallery({ attributes: { images } }: CoreGalleryProps) {
   return (
     <Container maxWidth="md">
-      <GridList data-testid={name} cellHeight={160} cols={4}>
+      <GridList data-testid="CoreGalleryBlock" cellHeight={160} cols={4}>
         {images?.map((image, i) => (
           <GridListTile key={`${i}-image-gallery`} cols={2} rows={1}>
             <img src={image.fullUrl} alt={image.alt} />

--- a/src/elements/block/core-heading/core-heading.composition.tsx
+++ b/src/elements/block/core-heading/core-heading.composition.tsx
@@ -3,5 +3,7 @@ import { Block } from '..'
 import { blocks } from '../blockData'
 
 export const HeadingBlock = () => (
-  <Block {...blocks.filter((block) => block.name === 'core/heading')[0]} />
+  <Block
+    {...blocks.filter((block) => block.__typename === 'CoreHeadingBlock')[0]}
+  />
 )

--- a/src/elements/block/core-heading/core-heading.spec.tsx
+++ b/src/elements/block/core-heading/core-heading.spec.tsx
@@ -5,7 +5,7 @@ import { CoreHeading } from '.'
 it('should render with the correct text', () => {
   const { getByText } = render(
     <CoreHeading
-      name="core/heading"
+      __typename="CoreHeadingBlock"
       attributes={{
         align: 'left',
         content: 'The parables from Matthew',
@@ -18,7 +18,7 @@ it('should render with the correct text', () => {
 it('should render with the correct alignment', () => {
   const { getByText } = render(
     <CoreHeading
-      name="core/heading"
+      __typename="CoreHeadingBlock"
       attributes={{
         align: 'left',
         content: 'The parables from Matthew',
@@ -35,7 +35,7 @@ it('should render with the correct alignment', () => {
 it('should default to alignment inherit', () => {
   const { getByText } = render(
     <CoreHeading
-      name="core/heading"
+      __typename="CoreHeadingBlock"
       attributes={{
         align: '',
         content: 'The parables from Matthew',

--- a/src/elements/block/core-heading/core-heading.tsx
+++ b/src/elements/block/core-heading/core-heading.tsx
@@ -15,12 +15,10 @@ export type CoreHeadingProps = {
    * container for heading attributes
    */
   attributes: Attributes
-  /** Variant style */
-  name: 'core/heading'
+  __typename: 'CoreHeadingBlock'
 }
 
 export function CoreHeading({
-  name,
   attributes: { level, content, align }
 }: CoreHeadingProps) {
   const variant = `h${level}` as TypographyVariant
@@ -28,7 +26,7 @@ export function CoreHeading({
   return (
     <Container>
       <Typography
-        data-testid={name}
+        data-testid="CoreHeadingBlock"
         variant={variant}
         gutterBottom
         align={normalized}>

--- a/src/elements/block/core-image/core-image.composition.tsx
+++ b/src/elements/block/core-image/core-image.composition.tsx
@@ -3,5 +3,7 @@ import { Block } from '..'
 import { blocks } from '../blockData'
 
 export const ImageBlock = () => (
-  <Block {...blocks.filter((block) => block.name === 'core/image')[0]} />
+  <Block
+    {...blocks.filter((block) => block.__typename === 'CoreImageBlock')[0]}
+  />
 )

--- a/src/elements/block/core-image/core-image.spec.tsx
+++ b/src/elements/block/core-image/core-image.spec.tsx
@@ -5,7 +5,7 @@ import { CoreImage } from '.'
 it('should render with the correct text', () => {
   const { getByRole } = render(
     <CoreImage
-      name="core/image"
+      __typename="CoreImageBlock"
       attributes={{
         id: 23,
         title: '',

--- a/src/elements/block/core-image/core-image.tsx
+++ b/src/elements/block/core-image/core-image.tsx
@@ -25,18 +25,16 @@ export type CoreImageProps = {
    * container for image attributes
    */
   attributes: Attributes
-  /** Variant style */
-  name: 'core/image'
+  __typename: 'CoreImageBlock'
 }
 
 export function CoreImage({
-  name,
   attributes: { alt, url, title, id }
 }: CoreImageProps) {
   const classes = useStyles()
   return (
     <img
-      data-testid={name}
+      data-testid="CoreImageBlock"
       id={`${id}`}
       src={url}
       alt={alt}

--- a/src/elements/block/core-list/core-list.composition.tsx
+++ b/src/elements/block/core-list/core-list.composition.tsx
@@ -3,5 +3,7 @@ import { Block } from '..'
 import { blocks } from '../blockData'
 
 export const ListBlock = () => (
-  <Block {...blocks.filter((block) => block.name === 'core/list')[0]} />
+  <Block
+    {...blocks.filter((block) => block.__typename === 'CoreListBlock')[0]}
+  />
 )

--- a/src/elements/block/core-list/core-list.spec.tsx
+++ b/src/elements/block/core-list/core-list.spec.tsx
@@ -5,7 +5,7 @@ import { CoreList } from '.'
 it('should render with the correct text', () => {
   const { getByText } = render(
     <CoreList
-      name="core/list"
+      __typename="CoreListBlock"
       attributes={{
         ordered: true,
         values:
@@ -20,7 +20,7 @@ it('should render with the correct text', () => {
 it('should render unordered', () => {
   const { getByText } = render(
     <CoreList
-      name="core/list"
+      __typename="CoreListBlock"
       attributes={{
         ordered: false,
         values:

--- a/src/elements/block/core-list/core-list.tsx
+++ b/src/elements/block/core-list/core-list.tsx
@@ -11,16 +11,14 @@ type Attributes = {
 }
 
 export type CoreListProps = {
-  /** Content */
+  /**
+   * container for list attributes
+   */
   attributes: Attributes
-  /** Variant style */
-  name: 'core/list'
+  __typename: 'CoreListBlock'
 }
 
-export function CoreList({
-  name,
-  attributes: { ordered, values }
-}: CoreListProps) {
+export function CoreList({ attributes: { ordered, values } }: CoreListProps) {
   const list = values
     .replace(/<\/li><li>/g, '*-*')
     .replace('</li>', '')
@@ -28,7 +26,7 @@ export function CoreList({
     .split('*-*')
 
   return (
-    <List data-testid={name}>
+    <List data-testid="CoreListBlock">
       {list.map((item, i) => (
         <ListItem key={i}>
           <ListItemText primary={ordered ? `${i + 1}. ${item}` : `- ${item}`} />

--- a/src/elements/block/core-paragraph/core-paragraph.composition.tsx
+++ b/src/elements/block/core-paragraph/core-paragraph.composition.tsx
@@ -3,5 +3,7 @@ import { Block } from '..'
 import { blocks } from '../blockData'
 
 export const ParagraphBlock = () => (
-  <Block {...blocks.filter((block) => block.name === 'core/paragraph')[0]} />
+  <Block
+    {...blocks.filter((block) => block.__typename === 'CoreParagraphBlock')[0]}
+  />
 )

--- a/src/elements/block/core-paragraph/core-paragraph.spec.tsx
+++ b/src/elements/block/core-paragraph/core-paragraph.spec.tsx
@@ -9,7 +9,7 @@ it('should render with the correct text', () => {
         content:
           "When people talk about the ministry of Jesus, it's easy to focus on his miracles. Jesus performed some amazing feats that the world had never seen (and hasn’t seen since). But one of the most exciting things about His ministry was His teaching style."
       }}
-      name="core/paragraph"
+      __typename="CoreParagraphBlock"
     />
   )
   const rendered = getByText(

--- a/src/elements/block/core-paragraph/core-paragraph.tsx
+++ b/src/elements/block/core-paragraph/core-paragraph.tsx
@@ -11,15 +11,14 @@ export type CoreParagraphProps = {
    * container for paragraph attributes
    */
   attributes: Attributes
-  /** Variant style */
-  name: 'core/paragraph'
+  __typename: 'CoreParagraphBlock'
 }
 
-export function CoreParagraph({ name, attributes }: CoreParagraphProps) {
+export function CoreParagraph({ attributes }: CoreParagraphProps) {
   return (
     <Container>
       <Typography
-        data-testid={name}
+        data-testid="CoreParagraphBlock"
         variant="body1"
         dangerouslySetInnerHTML={{ __html: attributes.content }}
         paragraph

--- a/src/elements/post/postData.ts
+++ b/src/elements/post/postData.ts
@@ -17,24 +17,24 @@ const postQuery = {
             content:
               "When people talk about the ministry of Jesus, it's easy to focus on his miracles. Jesus performed some amazing feats that the world had never seen (and hasn’t seen since). But one of the most exciting things about His ministry was His teaching style."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               '<a href="https://www.jesusfilm.org/blog-and-stories/40-facts-jesus.html">Jesus taught using parables</a>—simple stories intended to impart a spiritual lesson. He\'s so identified with this teaching style that&nbsp;<a href="https://www.jesusfilm.org/blog-and-stories/facts-gospel-mark.html">Mark\'s Gospel</a>&nbsp;tells us that "He did not say anything to them without using a parable" (Mark 4:34a).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'We\'ve collected all of Jesus\'s parables from the synoptic Gospels:&nbsp;<a href="https://www.jesusfilm.org/blog-and-stories/gospel-of-matthew.html">Matthew</a>, Mark, and&nbsp;<a href="https://www.jesusfilm.org/blog-and-stories/facts-gospel-luke.html">Luke</a>. With each parable, you\'ll discover:'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/list',
+          __typename: 'CoreListBlock',
           attributes: {
             ordered: false,
             values:
@@ -42,7 +42,7 @@ const postQuery = {
           }
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: 'The parables from Matthew',
@@ -54,10 +54,10 @@ const postQuery = {
             content:
               "Matthew was particularly focused on convincing the Jews that Jesus was the Messiah. One way that he accomplished that goal was by centering his message around Jesus’ teachings and how they intersected with Jewish faith and tradition. That's why we find so many parables that are unique to Matthew, like The Unmerciful Servant, The Workers in the Vineyard, and The Ten Virgins."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '1. The Parables of New Cloth and New Wineskins',
@@ -69,24 +69,24 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+9%3A16-17&amp;version=ESV">Matthew 9:16–17</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+2%3A21%E2%80%9322&amp;version=NIV">Mark 2:21–22</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+5%3A36%E2%80%9338&amp;version=NIV">Luke 5:36–38</a><br><strong>Audience:&nbsp;</strong>John the Baptist\'s disciples<br><strong>Context:</strong>&nbsp;John\'s disciples ask Jesus why the Pharisees fast, but His disciples do not.<br><strong>Key verse:&nbsp;</strong>&nbsp;"No one sews a patch of unshrunk cloth on an old garment, for the patch will pull away from the garment, making the tear worse" (Matthew 9:16).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The first-century religious establishment had expectations for the Messiah. In their understanding, He would come and build upon the traditions and practices of Judaism. Even John the Baptist's disciples didn't know how to understand why Jesus wasn't adhering to common Jewish observances."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus tells them that any attempt to patch up what was lacking in Judaism's traditional expressions of righteousness would only make everything worse. Like a piece of unshrunk cloth sewn into an old garment or a new wine in an old wineskin, Jesus was bringing something that wouldn’t fit into the religious traditions of the time."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '2. The Parable of the Lamp Stand',
@@ -98,31 +98,31 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+5%3A14%E2%80%9316&amp;version=NIV">Matthew 5:14–16</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+4%3A21%E2%80%9322&amp;version=NIV">Mark 4:21–22</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+8%3A16&amp;version=NIV">Luke 8:16</a><br><strong>Audience:&nbsp;</strong>A great crowd<br><strong>Context:</strong>&nbsp;The sermon on the mount<br><strong>Key Verse:</strong>&nbsp;"In the same way, let your light shine before others, that they may see your good deeds and glorify your Father in heaven" (Matthew 5:16).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "First-century homes in Palestine were modest, and it didn't take much light to illuminate them. People used very small oil lamps which could easily fit under a small bowl. But the idea of lighting a lamp and putting it under a bowl is absurd. Not only would it be a waste of light, but it would also be a waste of oil."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Like a lamp, followers of Jesus should be put in a place of prominence where the light within them can be seen clearly.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/salt-and-light.html">What Does It Mean to Be Salt and Light?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/image',
+          __typename: 'CoreImageBlock',
           attributes: {
             id: 23,
             href: '',
@@ -134,7 +134,7 @@ const postQuery = {
           }
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '3. The Parable of the Wise and Foolish Builders',
@@ -146,31 +146,31 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+7%3A24%E2%80%9327&amp;version=NIV">Matthew 7:24–27</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+6%3A47%E2%80%9349&amp;version=NIV">Luke 6:47–49</a><br><strong>Audience:&nbsp;</strong>A great crowd<br><strong>Context:&nbsp;</strong>The sermon on the mount<br><strong>Key Verse:</strong>&nbsp;"Therefore everyone who hears these words of mine and puts them into practice is like a wise man who built his house on the rock" (Matthew 7:24).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Hearing Jesus's words and putting them into practice is like building your home on a solid and trustworthy foundation that can withstand life's storms. Jesus contrasts that to the dangers of ignoring His words, which He compares to building one's life on sand."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'This would have been a shocking statement to people listening to Christ’s sermon because they believed the Torah was the most reliable foundation to build one’s life upon.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-wise-foolish-builders.html">What Is the Parable of the Wise and Foolish Builders About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '4. The Parable of the Sower',
@@ -182,17 +182,17 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A3%E2%80%9323%2C&amp;version=NIV">Matthew 13:3–23</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+4%3A3%E2%80%9320&amp;version=NIV">Mark 4:3–20</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+8%3A5%E2%80%9315&amp;version=NIV">Luke 8:5–15</a><br><strong>Audience:&nbsp;</strong>Large crowd<br><strong>Context:</strong>&nbsp;Jesus teaching beside a lake<br><strong>Key Verse:</strong>&nbsp;"But the seed falling on good soil refers to someone who hears the word and understands it. This is the one who produces a crop, yielding a hundred, sixty or thirty times what was sown" (Matthew 13:23).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'In the Parable of the Sower, Jesus uses the image of various kinds of soil to contrast different heart responses to the gospel:'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/list',
+          __typename: 'CoreListBlock',
           attributes: {
             ordered: false,
             values:
@@ -204,17 +204,17 @@ const postQuery = {
             content:
               "<br>Jesus's point in this parable is that how we receive the gospel is primarily determined by the condition of our heart."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post "<a href="https://www.jesusfilm.org/blog-and-stories/parable-of-sower.html">What Is the Parable of the Sower About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '5. The Parable of the Weeds',
@@ -226,31 +226,31 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A24%E2%80%9330&amp;version=NIV">Matthew 13:24–30</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A36-43&amp;version=NIV">36–43</a><br><strong>Audience:</strong>&nbsp;Large crowd<br><strong>Context:</strong>&nbsp;Jesus teaching beside a lake<br><strong>Key Verses:</strong>&nbsp;"\'No,\' he answered, \'because while you are pulling the weeds, you may uproot the wheat with them. Let both grow together until the harvest. At that time I will tell the harvesters: First collect the weeds and tie them in bundles to be burned; then gather the wheat and bring it into my barn\'" (Matthew 13:29–30).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Darnel is a weed that mimics wheat. In its younger stages, it's virtually indistinguishable from this vital crop. As it grows, it’s roots intertwine with the wheat and make it difficult to uproot without losing the grain, too. If a rival farmer wanted to hamstring another, he would come and sow darnel in another’s field."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus uses this word picture to communicate the dangers of judging whether someone else is a member of God's kingdom. At the end of the age, it will be God who sorts out the weeds from the wheat.&nbsp; &nbsp;"
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-the-weeds.html">What is the Meaning of the Parable of the Weeds?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '6. The Parable of the Mustard Seed',
@@ -262,24 +262,24 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A31%E2%80%9332&amp;version=NIV">Matthew 13:31–32</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+4%3A30%E2%80%9332&amp;version=NIV">Mark 4:30–32</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+13%3A18%E2%80%9319&amp;version=NIV">Luke 13:18–19</a><br><strong>Audience:&nbsp;</strong>Large crowd<br><strong>Context:</strong>&nbsp;Jesus teaching beside a lake<br><strong>Key Verse:&nbsp;</strong>"Though it is the smallest of all seeds, yet when it grows, it is the largest of garden plants and becomes a tree, so that the birds come and perch in its branches" (Matthew 13:32).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The kingdom of God would come from inauspicious beginnings and change the world. Even our calendar is determined by Jesus's coming. Jesus prophesied that this would be the case when he contrasted the kingdom of God with a mustard seed that starts small and grows into a tree capable of providing shelter."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/kingdom-god-mustard-seed.html">How Is the Kingdom of God Like a Mustard Seed?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '7. The Parable of the Leaven',
@@ -291,24 +291,24 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A33&amp;version=NIV">Matthew 13:33</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+13%3A20%E2%80%9321&amp;version=NIV">Luke 13:20–21</a><br><strong>Audience:&nbsp;</strong>Large crowd<br><strong>Context:&nbsp;</strong>Jesus teaching beside a lake<br><strong>Key Verse:&nbsp;</strong>"He told them still another parable: \'The kingdom of heaven is like yeast that a woman took and mixed into about sixty pounds of flour until it worked all through the dough\'" (Matthew 13:33).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'In the Parable of the Mustard Seed, Jesus explains that the kingdom of God would start small and grow immensely. In the Parable of the Leaven, He describes how that will happen. Like yeast working its way through the dough, the kingdom of God would flourish as it worked its way through cultures by traveling from individual to individual.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post "<a href="https://www.jesusfilm.org/blog-and-stories/parable-leaven.html">What Is the Parable of the Leaven About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '8. The Parables of the Hidden Treasure and the Pearl',
@@ -320,24 +320,24 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A44%E2%80%9346&amp;version=NIV">Matthew 13:44–46</a><br><strong>Audience:</strong>&nbsp;Large crowd<br><strong>Context:</strong>&nbsp;Jesus teaching beside a lake<br><strong>Key Verse:&nbsp;</strong>"The kingdom of heaven is like treasure hidden in a field. When a man found it, he hid it again, and then in his joy went and sold all he had and bought that field. Again, the kingdom of heaven is like a merchant looking for fine pearls. When he found one of great value, he went away and sold everything he had and bought it." (Matthew 13:44–46)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "These two parables share the same point. They express the value of God's kingdom by illustrating what we should be willing to give up to acquire it. In both of these parables, the kingdom is portrayed as valuable enough to warrant giving up everything to possess it."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at these parables, check out the post "<a href="https://www.jesusfilm.org/blog-and-stories/parables-treasure-and-pearl.html">What Are the Parables of the Hidden Treasure and Pearl About</a>?"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '9. The Parable of the Net',
@@ -349,17 +349,17 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A47%E2%80%9350&amp;version=NIV">Matthew 13:47–50</a><br><strong>Audience:</strong>&nbsp;Large crowd<br><strong>Context:&nbsp;</strong>Jesus teaching beside a lake<br><strong>Key Verse:</strong>&nbsp;"When it was full, the fishermen pulled it up on the shore. Then they sat down and collected the good fish in baskets, but threw the bad away" (Matthew 13:48).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'This parable is similar to the Parable of the Weeds. It has to do with the coming judgment at the end of the age. As the gospel is spread throughout the world, it attracts all sorts of people—some who are willing to take it seriously and others who are merely drawn to elements of the message. A time is coming when the real disciples will be separated from the false ones in the same way that fishermen would separate edible fish from inedible or unclean ones.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '10. The Parable of the Homeowner',
@@ -371,17 +371,17 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Matthew+13%3A52&amp;version=NIV">Matthew 13:52</a><br><strong>Audience:</strong>&nbsp;Large crowd<br><strong>Context:</strong>&nbsp;Jesus teaching beside a lake<br><strong>Key Verse:</strong>&nbsp;"He said to them, \'Therefore every teacher of the law who has become a disciple in the kingdom of heaven is like the owner of a house who brings out of his storeroom new treasures as well as old\'" (Matthew 13:52).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Throughout the Old Testament, we see foreshadowings of Jesus's ministry. Teachers of the law who chose to follow Jesus played a valuable role in the early church, helping to illuminate the connection between the teachings and prophecies of the Old Testament and Christ’s new covenant. Paul does this masterfully throughout the Epistles."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '11. The Parable of the Wandering Sheep',
@@ -393,38 +393,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+18%3A12%E2%80%9314&amp;version=NIV">Matthew 18:12–14</a><br><strong>Audience:</strong>&nbsp;The disciples<br><strong>Context:&nbsp;</strong>The disciples asked, "Who, then, is the greatest in the Kingdom of Heaven?" Jesus responded by teaching them about the importance of children. He then told them this parable.<br><strong>Key Verse:</strong>&nbsp;"In the same way your Father in heaven is not willing that any of these little ones should perish" (Matthew 18:14)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'While this parable is similar to the Parable of the Lost Sheep in Luke, Jesus is talking to the disciples and not the Pharisees here. He also seems to focus on caring for the vulnerable. The disciples ask who is greatest in the kingdom of heaven and Jesus singles out children.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "His point seems to be that those who would be passed over because of their lack of significance and contribution are great in the kingdom of heaven. This ties in perfectly with Jesus's consistent message of a great reversal, where the last will be first, and the first will be last."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus reiterates God's care for the wayward and vulnerable by comparing Himself to a shepherd who would leave 99 sheep in order to track down one who has gone astray."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-wandering-sheep.html">What Is the Parable of the Wandering Sheep About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '12. The Parable of the Unmerciful Servant',
@@ -436,31 +436,31 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+18%3A23%E2%80%9331&amp;version=NIV">Matthew 18:23–31</a><br><strong>Audience:&nbsp;</strong>The disciples<br><strong>Context:&nbsp;</strong>Peter asked Jesus how many times we must forgive someone who sins against us.<br><strong>Key Verse:</strong>&nbsp;"But when that servant went out, he found one of his fellow servants who owed him a hundred silver coins. He grabbed him and began to choke him. \'Pay back what you owe me!\' he demanded" (Matthew 18:28).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus illustrates the importance of forgiveness by telling the story of a king who forgives a servant of a debt he's utterly incapable of repaying. After receiving this incredible mercy, the servant assaults a fellow servant who owes him a small debt. The king is angered that the servant refused to extend the mercy he so freely received."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Through this parable, Jesus tells Peter (and us) that we should see the sins committed against us in the light of the sins God has forgiven us for. As we have been forgiven, we should also forgive.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-unmerciful-servant.html">What Is the Meaning of the Parable about the Unmerciful Servant?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '13. The Parable of the Workers in the Vineyard',
@@ -472,38 +472,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+20%3A1%E2%80%9316&amp;version=NIV">Matthew 20:1–16</a><br><strong>Audience:&nbsp;</strong>Crowds in Judea<br><strong>Context:</strong>&nbsp;Jesus teaching<br><strong>Key Verse:&nbsp;</strong>"So the last will be first, and the first will be last" (Matthew 20:16).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The Parable of the Workers tells the story of a landowner who hires four sets of laborers throughout the course of the day. When the work day is over, all the workers received the same wages. Those who were hired at the beginning of the day were angered that those who were hired late in the day received a full day's pay."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'The landowner points out that the early workers were fairly compensated and they’re jealous at the generosity the landowner showed the latecomers.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Israel was like the workers hired early in the morning. They had been part of God's plan from the beginning. Jesus was responding to the natural resentment that would come when God's kingdom would be opened to those from every nation."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-vineyard-workers.html">What Is the Parable of the Vineyard Workers About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '14. The Parable of the Two Sons',
@@ -515,31 +515,31 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+21%3A28%E2%80%9332&amp;version=NIV">Matthew 21:28–32</a><br><strong>Audience:</strong>&nbsp;Large crowd outside the temple<br><strong>Context:</strong>&nbsp;The chief priests have questioned Jesus\'s authority<br><strong>Key Verse:</strong>&nbsp;"For John came to you to show you the way of righteousness, and you did not believe him, but the tax collectors and the prostitutes did. And even after you saw this, you did not repent and believe him" (Matthew 21:32).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "In this parable, Jesus compares the obedience of the Pharisees and teachers of the law to those of the sinners following Jesus. Despite the outward expressions of compliance, the Pharisees never got around to obeying God. By comparison, the sinners in Christ's circle disobeyed God but had a change of heart."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'In the end, they were justified by their actual obedience and not just promising to be obedient.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-of-the-two-sons.html">What Is the Meaning of the Parable of the Two Sons?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '15. The Parable of the Tenants',
@@ -551,45 +551,45 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Matthew+21%3A33%E2%80%9344&amp;version=NIV">Matthew 21:33–44</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+12%3A1%E2%80%9311&amp;version=NIV">Mark 12:1–11</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+20%3A9%E2%80%9318&amp;version=NIV">Luke 20:9–18</a><br><strong>Audience:&nbsp;</strong>Large crowd outside the temple<br><strong>Context:</strong>&nbsp;The chief priests have questioned Jesus\'s authority<br><strong>Key Verse:</strong>&nbsp;"Therefore I tell you that the kingdom of God will be taken away from you and given to a people who will produce its fruit" (Matthew 21:43).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Right after sharing the Parable of the Two Sons, Jesus tells another story about a landowner who rented his vineyard to some farmers. When harvest came, the landowner sent servants to the tenants to collect his fruit.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'The tenants abused the servants (and even killed some), so the landowner decided to send his own son, assuming respect that was denied the servants would be shown to his heir. The tenants wind up killing him, too.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'The tenants in this story not only represent the chief priests and Pharisees but also the Israelites who had abused the prophets. Not only would they abuse God’s servants, but they were strategizing a way to dispose of Jesus Himself.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "This parable further explains why God's kingdom would make room for those from outside of Israel."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-tenants.html">What Is the Meaning of the Parable of the Tenants?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '16. The Parable of the Wedding Banquet',
@@ -601,38 +601,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+22%3A1%E2%80%9314&amp;version=NIV">Matthew 22:1–14</a><br><strong>Audience:</strong>&nbsp;Large crowd outside the temple<br><strong>Context:</strong>&nbsp;The chief priests have questioned Jesus\'s authority<br><strong>Key Verse:</strong>&nbsp;"Then he said to his servants, \'The wedding banquet is ready, but those I invited did not deserve to come\'" (Matthew 22:8).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "This parable is almost a combination of the Parable of the Tenants and the Parable of the Great Banquet (Luke 14:15–24). A king is throwing a wedding banquet, but after it's prepared, the guests who promised to attend provide excuses to bow out, and some actually kill the servants who showed up to collect them."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "In response, the king dispatches an army on the murderous guests, and then extends the invitation to anyone who would like to attend. As the king mingles with guests, he discovers a man who is not wearing the wedding garb that's been provided. The king ejects this man from the banquet."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus is reiterating the point that Israel’s religious leaders had disqualified themselves from the kingdom, so He was opening the kingdom up to the Gentiles. The twist at the end of the parable is that even the newly invited guests need to attired in the garb of grace that will come through Jesus's death and resurrection."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-great-banquet.html">What Is the Parable of the Great Banquet About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '17. The Parable of the Fig Tree',
@@ -644,24 +644,24 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+24%3A32%E2%80%9335&amp;version=NIV">Matthew 24:32–35</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+13%3A28%E2%80%9329&amp;version=NIV">Mark 13:28–29</a>,&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+21%3A+29%E2%80%9331&amp;version=NIV">Luke 21: 29–31</a><br><strong>Audience:</strong>&nbsp;The disciples<br><strong>Context:</strong>&nbsp;Jesus teaches the disciples about the end times<br><strong>Key Verse:</strong>&nbsp;"Even so, when you see all these things, you know that it is near, right at the door" (Matthew 24:33).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Fig trees are one of the few trees in Judea that lose their leaves every year. When fig trees began to grow their leaves, it was a sign that wheat was about ready to be harvested. Jesus is telling the disciples that the signs He gave them about what was to come (vs. 4–29) would signal that the end was upon them.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/why-jesus-curse-fig-tree.html">Why Did Jesus Curse the Fig Tree?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '18. The Parable of the Ten Virgins',
@@ -673,38 +673,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+25%3A1%E2%80%9313&amp;version=NIV">Matthew 25:1–13</a><br><strong>Audience:</strong>&nbsp;The disciples<br><strong>Context:</strong>&nbsp;Jesus teaches the disciples about the end times<br><strong>Key Verse:</strong>&nbsp;"Therefore keep watch, because you do not know the day or the hour" (Matthew 25:13).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "There's a lot of disagreement about the meaning of this parable. Its interpretation tends to be tied to the theological leanings of the individual interpreting it. At its most basic level though, it's simple to understand."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The parable is about 10 virgins who are waiting to accompany a bridegroom to the bride’s home as part of a traditional procession. When it is announced that he's on his way, only five of them are prepared with extra oil for their lamps. The unprepared virgins attempt to get oil from the others, but knowing that they'll run out, the prepared virgins refuse. The foolish virgins run to purchase fuel, but they miss the bridegroom and are unable to attend the wedding feast."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus is telling the disciples that His followers will be prepared for His coming. They're not going to be distracted and surprised when He comes."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-ten-virgins.html">What Is the Parable of the Ten Virgins About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '19. The Parable of the Talents',
@@ -716,38 +716,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+25%3A14%E2%80%9330&amp;version=NIV">Matthew 25:14–30,</a>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+19%3A12%E2%80%9327&amp;version=NIV">Luke 19:12–27</a><br><strong>Audience:&nbsp;</strong>The disciples<br><strong>Context:</strong>&nbsp;Jesus teaches the disciples about the end times<br><strong>Key Verse:</strong>&nbsp;"For whoever has will be given more, and they will have an abundance. Whoever does not have, even what they have will be taken from them" (Matthew 25:29).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The Parable of the Talents fits within the context of Jesus's end-times discussion. It operates as a natural follow-up to the story about the 10 virgins."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'This parable tells the story of a man going on a journey and entrusting three servants with varying amounts of money. When the master arrives to settle accounts with these servants, the two that he entrusted with the most significant amounts offer the master a return on his investment. The third servant simply hid the money he was given and gives it back to the master. The last servant is scolded and rejected for not turning any profit on the money he was entrusted with.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The immediate context points to this being a warning for Israel, but the application touches everyone who longs to be part of the kingdom. We are all responsible for stewarding the grace and resources we have received. They're not just ours to horde; they're ours to multiply."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-talents.html">What Is the Meaning of the Parable of the Talents?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '20. The Parable of the Sheep and the Goats',
@@ -759,17 +759,17 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Matthew+25%3A31%E2%80%9346&amp;version=NIV">Matthew 25:31–46</a><br><strong>Audience:</strong>&nbsp;The disciples<br><strong>Context:</strong>&nbsp;Jesus teaches the disciples about the end times<br><strong>Key Verse:</strong>&nbsp;"The King will reply, \'Truly I tell you, whatever you did for one of the least of these brothers and sisters of mine, you did for me\'" (Matthew 25:40).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus contrasts people who are separated at the end of days. In this parable, they're divided based on the service they’ve provided to the vulnerable including the:"
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/list',
+          __typename: 'CoreListBlock',
           attributes: {
             ordered: false,
             values:
@@ -781,24 +781,24 @@ const postQuery = {
             content:
               "<br>To everyone's complete surprise, Jesus so identifies with the vulnerable that he indicates that by serving them, they are actually serving Jesus Himself. Those that withheld care for the lowly are judged for withholding it from Jesus."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'If this was the only teaching of Jesus one was to hear, it would be easy to assume that redemption is based entirely on what we did or did not do. The application here is that saving faith produces fruit, and true followers of Christ are servants.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-sheep-and-goats.html">What’s the Parable of the Sheep and Goats about?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: 'The Parables of Mark',
@@ -810,17 +810,17 @@ const postQuery = {
             content:
               "Because it's shorter and was likely a source for the other accounts, there are only a couple of parables that are unique to Mark's Gospel."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'A few of the parables in Mark also show up in Matthew, including:'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/list',
+          __typename: 'CoreListBlock',
           attributes: {
             ordered: false,
             values:
@@ -828,7 +828,7 @@ const postQuery = {
           }
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '21. The Parable of the Growing Seed',
@@ -840,17 +840,17 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+4%3A26%E2%80%9329&amp;version=NIV">Mark 4:26–29</a><br><strong>Audience:</strong>&nbsp;Large crowd<br><strong>Context:</strong>&nbsp;Jesus teaching beside a lake<br><strong>Key Verse:</strong>&nbsp;"All by itself the soil produces grain—first the stalk, then the head, then the full kernel in the head" (Mark 4:28).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "As Israel awaited its Messiah, it looked forward to a kingdom that would burst upon the scene and restore God's rule. In much the same way as He does in the parable of the leaven, Jesus says that will not be the case. The kingdom will grow almost inconspicuously in the midst of the world’s kingdoms."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '22. The Parable of the Returning Owner',
@@ -862,24 +862,24 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Mark+13%3A34%E2%80%9337&amp;version=NIV">Mark 13:34–37</a><br><strong>Audience:</strong>&nbsp;The disciples<br><strong>Context:</strong>&nbsp;Jesus teaching the disciples about the end times<br><strong>Key Verse:&nbsp;</strong>"What I say to you, I say to everyone: \'Watch!\'" (Mark 13:37)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'This simple parable teaches a similar lesson as the parable of the 10 virgins and occurs during the same teaching of the end times. Jesus compares the coming of the kingdom to a master leaving his servants in charge of their responsibilities while he is away. They should be busy and watchful because they do not know when their master will return.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/whats-parable-returning-owner-about.html">What\'s the Parable of the Returning Owner About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: 'The Parables of Luke',
@@ -891,16 +891,16 @@ const postQuery = {
             content:
               "The Gospel of Luke is the longest book in the New Testament. Compiled from eyewitness accounts, Luke's has a lot of distinct insight into the life and teachings of Jesus—including more than 15 unique parables."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content: 'There are a number of parables that overlap with Matthew:'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/list',
+          __typename: 'CoreListBlock',
           attributes: {
             ordered: false,
             values:
@@ -908,7 +908,7 @@ const postQuery = {
           }
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '23. The Parable of the Moneylender',
@@ -920,31 +920,31 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+7%3A41%E2%80%9343&amp;version=NIV">Luke 7:41–43</a><br><strong>Audience:&nbsp;</strong>Those present at a Pharisee’s dinner party<br><strong>Context:</strong>&nbsp;A sinful woman anoints Jesus\'s feet at a dinner party. The host (a Pharisee) mutters to himself that Jesus can\'t be a prophet because He\'s allowing this sinful woman to touch Him.<br><strong>Key Verse:</strong>&nbsp;"Neither of them had the money to pay him back, so he forgave the debts of both. Now which of them will love him more?" (Luke 7:42)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "In response to the Pharisee's judgment upon the sinful woman, Jesus offers up a brief story about multiple debtors. Each one owed a dramatically different amount, but the moneylender forgave all their debts."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "He asked the Pharisee which one of the debtors would love the lender most? The Pharisee responds that the person who was forgiven the greater debt would love the most. Jesus confirms that this is the right answer, His point being that this sinful woman (and others like her) would love God more because of the mercy they've been shown."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post "<a href="https://www.jesusfilm.org/blog-and-stories/what-is-meaning-moneylender-parable.html">What Is the Meaning of the Moneylender Parable?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '24. The Parable of the Rich Fool',
@@ -956,38 +956,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+12%3A16%E2%80%9321&amp;version=NIV">Luke 12:16–21</a><br><strong>Audience:</strong>&nbsp;The disciples within earshot of a larger crowd<br><strong>Context:&nbsp;</strong>A man asked Jesus to intervene in a disagreement about an inheritance<br><strong>Key Verse:</strong>&nbsp;"But God said to him, \'You fool! This very night your life will be demanded from you. Then who will get what you have prepared for yourself?\'" (Luke 12:20)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'A man comes to Jesus to mediate a disagreement with his brother about an inheritance. Jesus rebukes the man and warns him to be on guard against greed.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "He then tells the story of a wealthy man who used his farming profits to build bigger barns and store up grain that would serve him in his old age. That way, when he was older, he could relax and not struggle to meet his own needs. Unfortunately, he didn't realize that he was going to die and the surplus of goods he had saved would just be passed on to someone else."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'By worldly standards, the rich man didn’t make a foolish decision. In light of eternity, however, he had neglected to make himself rich in the things that mattered to God—and would ultimately serve him for eternity.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-the-rich-fool.html">What\'s the Meaning of the Parable of the Rich Fool?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '25. The Parable of the Watchful Servants',
@@ -999,17 +999,17 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+12%3A35-40&amp;version=NIV">Luke 12:35-40</a><br><strong>Audience:&nbsp;</strong>The disciples within earshot of a larger crowd<br><strong>Context:</strong>&nbsp;Jesus teaching about the coming of the kingdom<br><strong>Key Verse:</strong>&nbsp;"It will be good for those servants whose master finds them ready, even if he comes in the middle of the night or toward daybreak" (Luke 12:38).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "This parable about watchfulness is particularly focused on Christ's second coming, which he likens to a thief's arrival. It's one thing for a servant to be watchful enough to answer a knock at the door; it's quite another for him to be prepared for a robber who shows up unannounced. Jesus encourages His servants to demonstrate that level of alertness."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '26. The Parable of the Wise and Foolish Servants',
@@ -1021,31 +1021,31 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Luke+12%3A42%E2%80%9348&amp;version=NIV">Luke 12:42–48</a><br><strong>Audience:</strong>&nbsp;The disciples within earshot of a larger crowd<br><strong>Context:</strong>&nbsp;In response to the Parable of the Watchful Servants, Peter asks Jesus if He is speaking to the disciples or the gathered crowd.<br><strong>Key Verse:&nbsp;</strong>"It will be good for that servant whom the master finds doing so when he returns" (Luke 12:43).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Peter wants to know who Jesus is instructing to be watchful. Is He just speaking to the disciples or is He instructing everyone? Jesus responds with another parable.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "A master puts a manager in charge of his servants while he is away. It’s the manager's duty to ensure that the servants are fed and paid on time. But what would happen if that manager took advantage of his freedom and responsibility? What if he figured the master wouldn't return soon, so he became self-indulgent and abusive? The master would show up unannounced and put that manager to death."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus is addressing the disciples who would be put in positions of authority in His household, but He is also addressing everyone else who finds themselves in positions of authority within the church. Be vigilant and make sure you are at your Master's business when He returns."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '27. The Parable of the Unfruitful Fig Tree',
@@ -1057,24 +1057,24 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Luke+13%3A6%E2%80%939&amp;version=NIV">Luke 13:6–9</a><br><strong>Audience:&nbsp;</strong>The disciples within earshot of a larger crowd<br><strong>Context:</strong>&nbsp;Some in the crowd tell Jesus of a tragedy which had befallen some Galileans. Jesus challenges the idea that they suffered as judgment. He then calls the whole crowd to repent with this parable.<br><strong>Key Verse:</strong>&nbsp;"If it bears fruit next year, fine! If not, then cut it down" (Luke 13:9).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'A man is tired of the fruit tree growing in his vineyard not producing fruit. He tells the caretaker to cut it down. The caretaker asks for an opportunity to make it fruitful. The vineyard owner concedes but gives him one year to make it fruitful. If it doesn’t produce fruit next year, it is to be discarded.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus expects fruit from His followers, but like the fig tree, we don't know when our time is up. We cannot wait forever to begin producing fruit."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '28. The Parable of the Master and the Servant',
@@ -1086,24 +1086,24 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+17%3A7%E2%80%9310&amp;version=NIV">Luke 17:7–10</a><br><strong>Audience:&nbsp;</strong>The disciples<br><strong>Context:</strong>&nbsp;Jesus is telling His disciples what He expects of them<br><strong>Key Verse:&nbsp;</strong>&nbsp;"So you also, when you have done everything you were told to do, should say, \'We are unworthy servants; we have only done our duty\'" (Luke 17:10).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "To remind the disciples about how the kingdom's chain of command works, Jesus asks them to imagine a scenario where a servant has come inside from a day of fulfilling his responsibilities. The master doesn't then wait on the servant. Instead, the servant serves the master and waits patiently before he eats. This is the servant's duty."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus doesn't tell this story dismissively, as if the disciples are just slaves. Instead, He wants the disciples to understand that they have been brought into the God's kingdom out of kindness. God owes them nothing, and they owe Him everything."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '29. The Parable of the Good Samaritan',
@@ -1115,38 +1115,38 @@ const postQuery = {
             content:
               "<strong>Passage:</strong>&nbsp;<a href=\"https://www.biblegateway.com/passage/?search=Luke+10%3A30%E2%80%9337&amp;version=NIV\">Luke 10:30–37</a><br><strong>Audience:&nbsp;</strong>A teacher of the law (and likely the disciples)<br><strong>Context:</strong>&nbsp;A lawyer asks Jesus what he must do to inherit eternal life. Once it's established that the whole of the law is summed up in loving God and loving your neighbor as yourself, the lawyer tries to wriggle out of the responsibility to love his neighbor by asking, \"Who is my neighbor?\"<br><strong>Key Verses:</strong>&nbsp;\"'Which of these three do you think was a neighbor to the man who fell into the hands of robbers?' The expert in the law replied, 'The one who had mercy on him.' Jesus told him, 'Go and do likewise'\" (Luke 10:36–37)."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Jesus shocks the lawyer with a parable about a man who is robbed, beaten, and left for dead. A priest and Levite (servant to priests) come by but do not stop to help the man. But then a Samaritan comes along who tends to the man and pays to put him up in an inn until he recovers.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "We miss the shocking nature of this parable because we don't understand just how much Jews hated Samaritans. This hatred went back hundreds of years. To admit that it was the Samaritan who was a true neighbor to this man and not a fellow Jew would have been hard for the lawyer."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'The application is that everyone is capable of being our neighbor—and we are responsible for being a neighbor to everyone.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post "<a href="https://www.jesusfilm.org/blog-and-stories/parable-good-samaritan.html">What Is the Parable of the Good Samaritan About</a>?"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '30. The Parable of the Friend Seeking Bread',
@@ -1158,24 +1158,24 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Luke+11%3A5%E2%80%938&amp;version=NIV">Luke 11:5–8</a><br><strong>Audience:&nbsp;</strong>The disciples<br><strong>Context:</strong>&nbsp;One of the disciples asked Jesus to teach them how to pray. After teaching them the Lord\'s Prayer, He gives them this parable.<br><strong>Key Verse:&nbsp;</strong>"I tell you, even though he will not get up and give you the bread because of friendship, yet because of your shameless audacity he will surely get up and give you as much as you need" (Luke 11:8).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus wants His followers to have the courage to make bold requests and pray until God moves. To illustrate this, He gives a parable about a man whose friend shows up in the middle of the night, but he doesn't have any food to offer him. So, this man goes to another friend and wakes him up to borrow some bread. It's incredibly inconvenient to help, but the third friend ends up responding because of the tenacity &nbsp;of the request."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus isn't comparing God and the sleeping friend. He's actually contrasting them. If a friend is moved enough by your audacity to act on your behalf, how much more is God who loves you?"
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '31. The Parable of the Place of Honor',
@@ -1187,38 +1187,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+14%3A7%E2%80%9311&amp;version=NIV">Luke 14:7–11</a><br><strong>Audience:</strong>&nbsp;Guests at a Pharisee’s dinner party<br><strong>Context:</strong>&nbsp;Jesus is watching these guests choosing the best seats<br><strong>Key Verse:&nbsp;</strong>"For all those who exalt themselves will be humbled, and those who humble themselves will be exalted" (Luke 14:11).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "It's almost comical how pointed this parable is. Jesus was invited to dine at the home of a Pharisee, and He was watching guests arrive and jockey for the best positions. He responds with a parable that would have been taken as a very specific criticism."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "He tells them that at a wedding party you should never choose the place of honor. That way if someone more distinguished arrives, the host won't have to ask you to move and humiliate you. Instead, take the lowest place. That way, when you’re asked to move up, you will be honored."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The more significant application had to do with the Pharisees' perceived prominence in God's kingdom. Jesus often warned that a great reversal was coming where the first would be last. He was encouraging them to prepare for that day."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/what-parable-of-honor-about.html">What Is the Parable of Honor About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '32. The Parable of the Great Banquet',
@@ -1230,38 +1230,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+14%3A16%E2%80%9324&amp;version=NIV">Luke 14:16–24</a><br><strong>Audience:</strong>&nbsp;Guests at a Pharisee’s dinner party<br><strong>Context:</strong>&nbsp;In response to the Parable of the Place of Honor, someone responded, "Blessed is the one who will eat at the feast in the kingdom of God."<br><strong>Key Verse:</strong>&nbsp;"I tell you, not one of those who were invited will get a taste of my banquet" (Luke 14:24).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "After sharing the Parable of the Place of Honor, a man responds with a toast to those who are blessed enough to eat at the feast of the kingdom of God. It's almost as if he completely missed the point of Christ's words. So Jesus tells a more challenging parable."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "A man was putting on a banquet and invited many guests. When he sent his servants to collect the people who promised to attend, they offered excuses for why they couldn't come. When the master heard that the guests had blown off his event, he sent his servant out to invite those on the bottom of society's ladder: the poor, lame, blind, etc. He then sent the servant out to invite travelers to come to the party."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus was trying to tell them that He was here to collect them for God's celebration, but they were refusing Him. In their stead, He was going to fill the kingdom with people the Pharisees didn't think belonged."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post "<a href="https://www.jesusfilm.org/blog-and-stories/parable-great-banquet.html">What Is the Parable of the Great Banquet About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '33. Parables about Counting the Cost',
@@ -1273,17 +1273,17 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+14%3A28%E2%80%9333&amp;version=NIV">Luke 14:28–33</a><br><strong>Audience:</strong>&nbsp;A large crowd<br><strong>Context:&nbsp;</strong>People speaking to the crowds who were following Him<br><strong>Key Verse:</strong>&nbsp;"Suppose one of you wants to build a tower. Won\'t you first sit down and estimate the cost to see if you have enough money to complete it?" (Luke 14:28)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus never seemed interested in attracting a crowd for its own sake. He knew that people were drawn to Him because of His miracles and celebrity. He always challenged their motives. Here Luke tells us that Jesus randomly turns to the crowd that's following after Him and starts talking about the cost of discipleship."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/gallery',
+          __typename: 'CoreGalleryBlock',
           attributes: {
             align: 'left',
             images: [
@@ -1313,17 +1313,17 @@ const postQuery = {
             content:
               "He tells them, \"Imagine wanting to build a tower. Wouldn't you count the cost before you started so that you don't have to abandon the project halfway through? Or consider a king about to go to war. Doesn't he ponder the size of his army, and if he knows he can't win, doesn't he look to strike a deal?\""
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "He's telling them to seriously consider the cost associated with following Him."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '34. The Parable of the Lost Sheep',
@@ -1335,17 +1335,17 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+15%3A3%E2%80%937&amp;version=NIV">Luke 15:3–7</a><br><strong>Audience:</strong>&nbsp;A large crowd (including tax collectors, sinners, Pharisees, and teachers of the law)<br><strong>Context:</strong>&nbsp;As Jesus speaks to the crowd, the Pharisees begin grumbling about the low moral quality of the people Jesus associated with<br><strong>Key Verse:</strong>&nbsp;"I tell you that in the same way there will be more rejoicing in heaven over one sinner who repents than over ninety-nine righteous persons who do not need to repent" (Luke 15:7)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "When Jesus overhears Pharisees disparaging Him for associating with sinners, He begins instructing them about God's passion for the lost. In God's economy, a shepherd leaves his flock to find a single lost sheep—and upon finding it, he rejoices."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '35. The Parable of the Lost Coin',
@@ -1357,17 +1357,17 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Luke+15%3A8%E2%80%9310&amp;version=NIV">Luke 15:8–10</a><br><strong>Audience:&nbsp;</strong>A large crowd (including tax collectors, sinners, Pharisees, and teachers of the law)<br><strong>Context:</strong>&nbsp;As Jesus speaks to the crowd, the Pharisees begin grumbling about the low moral quality of the people Jesus associated with.<br><strong>Key Verse:&nbsp;</strong>"In the same way, I tell you, there is rejoicing in the presence of the angels of God over one sinner who repents" (Luke 15:10).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'After the Parable of the Lost Sheep, Jesus offers another parable intended to communicate the same truth. God is like a woman who loses one of her 10 silver coins, and she overturns the house until she finds it. Once she does, she calls all her friends to celebrate the recovery of this coin.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '36. The Parable of the Prodigal Son',
@@ -1379,45 +1379,45 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+15%3A11%E2%80%9332&amp;version=NIV">Luke 15:11–32</a><br><strong>Audience:</strong>&nbsp;A large crowd (including tax collectors, sinners, Pharisees, and teachers of the law)<br><strong>Context:&nbsp;</strong>As Jesus speaks to the crowd, the Pharisees begin grumbling about the low moral quality of the people Jesus associated with.<br><strong>Key Verse:&nbsp;</strong>"\'My son,\' the father said, \'you are always with me, and everything I have is yours\'" (Luke 15:31).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus rounds out the trifecta of parables about lost things with a story of a wayward son. While this parable is famously known as the story of the prodigal son, it's really a parable about the older brother."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "In this parable, a son asks his dad to give him his inheritance early. The father does, and the son leaves home. It doesn't take too long before his entire portion of the estate is squandered, and at that point, the country is hit with a famine. The son ends up tending to pigs and finds himself longing to eat what the pigs have."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'He decides to go home, and as he nears the home of his youth, his father runs out to meet him. He apologizes to his father, and his father—so happy to have him home—lavishes attention on him and decides to throw a big party for his return.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'At the end of the story, we find out that the older brother resents the attention his little brother is receiving. After all, he stayed home and worked faithfully. Meanwhile, his brother left, squandered all he had, and got to return home for a party in his honor. The father assures him, "all that I have is yours. But your brother was lost and now he\'s found."'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "This parable not only reiterates God’s tender love for the lost, but it's also a rebuke for the Pharisees who resent the sinners and tax collectors gathering around Jesus."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '37. The Parable of the Shrewd Manager',
@@ -1429,31 +1429,31 @@ const postQuery = {
             content:
               '<strong>Passage:&nbsp;</strong><a href="https://www.biblegateway.com/passage/?search=Luke+16%3A1%E2%80%939&amp;version=NIV">Luke 16:1–9</a><br><strong>Audience:</strong>&nbsp;A large crowd (including tax collectors, sinners, Pharisees, and teachers of the law)<br><strong>Context:</strong>&nbsp;Jesus continues to teach.<br><strong>Key Verse:</strong>&nbsp;"I tell you, use worldly wealth to gain friends for yourselves, so that when it is gone, you will be welcomed into eternal dwellings" (Luke 16:9).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Of all Jesus's parables, this is one of the most confusing. Most parables make it easy to discern who the characters are intended to represent, but in this one, all of the characters seem to be a little unethical and dishonest. The point of this parable isn't that we should emulate one of the characters, but rather, understand the principle."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "A rich man finds out his manager has been wasting his resources, so he fires him. Not wanting to beg or work a manual labor position, the manager cooks up a scheme to save himself. He calls up all the people that owe the manager, and he cuts their bills in half. This way the master can get paid, and the people will owe him. He intends to leverage what he's saved those debtors into a future job offer."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Jesus\'s point is that unscrupulous people are often more shrewd with their resources than godly people. But where the shrewd manager was able to use money to secure a future for himself, we can use money to "lay up treasures in heaven" (Matthew 6:20). We need to use our resources in a way that considers our long-term goals.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '38. The Parable of the Rich Man and Lazarus',
@@ -1465,45 +1465,45 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+16%3A19%E2%80%9331&amp;version=NIV">Luke 16:19–31</a><br><strong>Audience:</strong>&nbsp;A large crowd (including tax collectors, sinners, Pharisees, and teachers of the law)<br><strong>Context:&nbsp;</strong>The Pharisees scoffed at Jesus because of their love of money.<br><strong>Key Verse:</strong>&nbsp;"He said to him, \'If they do not listen to Moses and the Prophets, they will not be convinced even if someone rises from the dead\'" (Luke 16:31).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Like most parables, the story of the rich man and Lazarus has one central point. It's easy to get bogged down in the details and try to make this parable provide information about the afterlife that Jesus probably never intended."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'This is another story about the great reversal at the end of the age. It concerns an extremely wealthy man who passes by a poor beggar named Lazarus every day. When they both die, the rich man finds himself in torment in Hades while Lazarus is in paradise with the Jewish patriarch, Abraham.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The rich man begs Abraham to send Lazarus back, so he can warn his brothers that they need to change their ways. Abraham says, no. They had all of the instruction in the law about justice and how to treat the poor. If they chose to ignore that, they'd also ignore someone who rose from the dead."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Jesus's point is clear. We are responsible for acting on the truth that we know."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a closer look at this parable, check out the post “<a href="https://www.jesusfilm.org/blog-and-stories/parable-rich-man-lazarus.html">What is the Parable of the Rich Man and Lazarus About?</a>"'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '39. The Parable of the Persistent Widow',
@@ -1515,38 +1515,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+18%3A2%E2%80%938&amp;version=NIV">Luke 18:2–8</a><br><strong>Audience:</strong>&nbsp;The disciples<br><strong>Context:</strong>&nbsp;Teaching about persistent prayer<br><strong>Key Verse:</strong>&nbsp;"And will not God bring about justice for his chosen ones, who cry out to him day and night? Will he keep putting them off?" (Luke 18:7)'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'To teach the disciples about praying without giving up, Jesus told a story about a widow who had a case before a crooked judge. Without the ability to pay him off, all she could do was pester him for justice. Over time, she wore the judge down, and he ruled in her favor.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'While Jesus is encouraging us to model our prayer life after this widow, He is not saying that the crooked judge is like God. In fact, His point is that if even a bad judge can be worn down over time, how much more the Creator of the universe who wants to give you every good thing?'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For a little more insight, check out&nbsp;<a href="https://www.jesusfilm.org/blog-and-stories/3-lessons-on-prayer-from-parables.html">Three Lessons on Prayer from the Parables of Jesus</a>.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'You can also learn more about the topic of justice in “<a href="https://www.jesusfilm.org/blog-and-stories/24-informative-bible-verses-about-justice.html">24 Informative Bible Verses about Justice</a>.”'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: '40. The Parable of the Pharisee and the Tax Collector',
@@ -1558,38 +1558,38 @@ const postQuery = {
             content:
               '<strong>Passage:</strong>&nbsp;<a href="https://www.biblegateway.com/passage/?search=Luke+18%3A10%E2%80%9314&amp;version=NIV">Luke 18:10–14</a><br><strong>Audience:&nbsp;</strong>A large crowd<br><strong>Context:</strong>&nbsp;"To some who were confident of their own righteousness and looked down on everyone else, Jesus told this parable" (Luke 18:9):<br><strong>Key Verse:</strong>&nbsp;"For all those who exalt themselves will be humbled, and those who humble themselves will be exalted" (Luke 18:14b).'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "Self-righteousness is one trait that Jesus didn't seem to suffer gladly. He used the Parable of the Pharisee and the Tax Collector as a way to communicate the dangers of thinking too highly of yourself."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'A tax collector and a Pharisee went up to pray, and the Pharisee spent most of his time congratulating himself for how righteous he was—even going so far as to thank God that he wasn’t a sinner like the tax-gatherer. But the tax collector beat his breast and asked God to have mercy on him.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'According to Jesus, it was the tax collector who went home justified.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'For more insight, check out&nbsp;<a href="https://www.jesusfilm.org/blog-and-stories/3-lessons-on-prayer-from-parables.html">Three Lessons on Prayer from the Parables of Jesus</a>.'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: 'Are there any parables in the Gospel of John?',
@@ -1601,10 +1601,10 @@ const postQuery = {
             content:
               "While the&nbsp;<a href=\"https://www.jesusfilm.org/blog-and-stories/gospel-of-john.html\">Gospel of John</a>&nbsp;includes allegories like the good shepherd (John 10:1–5) and the childbearing woman (John 16:21), it's surprisingly lacking in parables. But this is likely because John's whole purpose was to prove that Jesus was the Messiah and Son of God and encourage people to believe (John 20:30–31). This goal caused him to focus more on the miraculous nature of Jesus's ministry and the theological implications of His incarnation. &nbsp;"
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
-          name: 'core/heading',
+          __typename: 'CoreHeadingBlock',
           attributes: {
             align: 'left',
             content: 'A teacher with authority',
@@ -1616,21 +1616,21 @@ const postQuery = {
             content:
               "Luke tells us that people were astonished at Jesus's teaching because He taught like someone with authority. This is particularly impressive when you consider the fact that Jesus's teachings and stories were so simple. We often have the mistaken view that the more intelligent and complex an idea sounds, the more impressive it is. Jesus didn't see it that way."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               "The parables of Jesus made the wisdom of God accessible. His teaching wasn't pretentious or unnecessarily complicated. And because of that, Jesus made the kingdom of God attainable for everyone."
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         },
         {
           attributes: {
             content:
               'Watch all of the parables come to life through the&nbsp;<a href="https://www.jesusfilm.org/watch/jesus.html/english.html">"JESUS" film</a>!'
           },
-          name: 'core/paragraph'
+          __typename: 'CoreParagraphBlock'
         }
       ] as BlockProps[],
       categories: {


### PR DESCRIPTION
API does not generate a union type for block.name. It does however, generate a union type for __typename.